### PR TITLE
ST-279 JWT Submitted twice for immediate payment THREEDQUERY only - master

### DIFF
--- a/src/components/control-frame/ControlFrame.ts
+++ b/src/components/control-frame/ControlFrame.ts
@@ -185,6 +185,9 @@ export default class ControlFrame extends Frame {
   // @TODO STJS-205 refactor into Payments
   private _processPayment(data: IResponseData) {
     if (this._postThreeDRequestTypes.length === 0) {
+      if (data.threedresponse !== undefined) {
+        StCodec.publishResponse(this._threeDQueryResult.response, this._threeDQueryResult.jwt, data.threedresponse);
+      }
       this.setNotification(NotificationType.Success, Language.translations.PAYMENT_SUCCESS);
     } else {
       this._payment

--- a/src/components/control-frame/ControlFrame.ts
+++ b/src/components/control-frame/ControlFrame.ts
@@ -185,7 +185,6 @@ export default class ControlFrame extends Frame {
   // @TODO STJS-205 refactor into Payments
   private _processPayment(data: IResponseData) {
     if (this._postThreeDRequestTypes.length === 0) {
-      StCodec.publishResponse(this._threeDQueryResult.response, this._threeDQueryResult.jwt, data.threedresponse);
       this.setNotification(NotificationType.Success, Language.translations.PAYMENT_SUCCESS);
     } else {
       this._payment

--- a/src/core/classes/CommonFrames.class.ts
+++ b/src/core/classes/CommonFrames.class.ts
@@ -154,10 +154,10 @@ export default class CommonFrames extends RegisterFrames {
 
   private getSubmitFields(data: any) {
     const fields = this.submitFields;
-    if (data.hasOwnProperty('jwt')) {
+    if (data.hasOwnProperty('jwt') && fields.indexOf('jwt') === -1) {
       fields.push('jwt');
     }
-    if (data.hasOwnProperty('threedresponse')) {
+    if (data.hasOwnProperty('threedresponse') && fields.indexOf('threedresponse') === -1) {
       fields.push('threedresponse');
     }
     return fields;


### PR DESCRIPTION
When the merchant asks for only the ["THREEDQUERY"] to be processed the THREEDQUERY response jwt was being added to the form twice instead of once, this is because the CommonFrames was publishing twice (once at end of THREEDQUERY and once after working out it was frictionless)

Updated so only the publishing at the end of the THREEDQUERY not when frictionless 