### PR TITLE
Hotfix/apple pay supported networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Add option for buttonId in config to allow a specific button to be targetted as the pay button (previously this was always targetting the first button only). If not specified this will keep the original behavior.
 - Improved behavioural tests to be able to more easily define more configuration options for additional test cases.
+- Allow ApplePay supportedNetworks to be overridden in config rather than always using only the supported versions for the current device.
 
 ## 2.0.0
 

--- a/src/core/integrations/ApplePay.ts
+++ b/src/core/integrations/ApplePay.ts
@@ -231,15 +231,28 @@ export class ApplePay {
    * @private
    */
   private _setSupportedNetworks() {
+    let supportedNetworks;
     if (this.applePayVersion <= ApplePay.APPLE_PAY_MIN_VERSION) {
-      this._paymentRequest.supportedNetworks = ApplePay.BASIC_SUPPORTED_NETWORKS;
+      supportedNetworks = ApplePay.BASIC_SUPPORTED_NETWORKS;
     } else if (
       this.applePayVersion > ApplePay.APPLE_PAY_MIN_VERSION &&
       this.applePayVersion < ApplePay.APPLE_PAY_MAX_VERSION
     ) {
-      this._paymentRequest.supportedNetworks = ApplePay.VERSION_4_SUPPORTED_NETWORKS;
+      supportedNetworks = ApplePay.VERSION_4_SUPPORTED_NETWORKS;
     } else {
-      this._paymentRequest.supportedNetworks = ApplePay.VERSION_5_SUPPORTED_NETWORKS;
+      supportedNetworks = ApplePay.VERSION_5_SUPPORTED_NETWORKS;
+    }
+    if (this._paymentRequest.supportedNetworks.length > 0) {
+      const userDefinedSupportedNetworks: string[] = [];
+      let i;
+      for (i in supportedNetworks) {
+        if (this._paymentRequest.supportedNetworks.indexOf(supportedNetworks[i]) !== -1) {
+          userDefinedSupportedNetworks.push(supportedNetworks[i]);
+        }
+      }
+      this._paymentRequest.supportedNetworks = userDefinedSupportedNetworks;
+    } else {
+      this._paymentRequest.supportedNetworks = supportedNetworks;
     }
   }
 
@@ -258,9 +271,7 @@ export class ApplePay {
       : (this._buttonText = ApplePay.AVAILABLE_BUTTON_TEXTS[0]);
 
     // tslint:disable-next-line: max-line-length
-    this._applePayButtonProps.style = `-webkit-appearance: -apple-pay-button; -apple-pay-button-type: ${
-      this._buttonText
-    }; -apple-pay-button-style: ${this._buttonStyle}`;
+    this._applePayButtonProps.style = `-webkit-appearance: -apple-pay-button; -apple-pay-button-type: ${this._buttonText}; -apple-pay-button-style: ${this._buttonStyle}`;
   }
 
   /**

--- a/test/core/integrations/ApplePay.spec.ts
+++ b/test/core/integrations/ApplePay.spec.ts
@@ -126,11 +126,29 @@ describe('ApplePay', () => {
     // then
     it(`should set proper networks when Apple Pay version is equal ${applePayVersions[3]}`, () => {
       // @ts-ignore
+      instance._paymentRequest.supportedNetworks = ApplePay.VERSION_5_SUPPORTED_NETWORKS;
+      // @ts-ignore
+      setPropertiesForVersion(applePayVersions[3], ApplePay.VERSION_5_SUPPORTED_NETWORKS);
+    });
+    // then
+    it(`should set subset of supported networks if merchant specifies subset ${applePayVersions[3]}`, () => {
+      // @ts-ignore
+      instance._paymentRequest.supportedNetworks = ['amex', 'visa'];
+      // @ts-ignore
+      setPropertiesForVersion(applePayVersions[3], ['amex', 'visa']);
+    });
+    // then
+    it(`should set full set of supported networks if merchant specifies empty array ${applePayVersions[3]}`, () => {
+      // @ts-ignore
+      instance._paymentRequest.supportedNetworks = [];
+      // @ts-ignore
       setPropertiesForVersion(applePayVersions[3], ApplePay.VERSION_5_SUPPORTED_NETWORKS);
     });
 
     // then
     it(`should set proper networks when Apple Pay version is equal ${applePayVersions[2]}`, () => {
+      // @ts-ignore
+      instance._paymentRequest.supportedNetworks = ApplePay.VERSION_4_SUPPORTED_NETWORKS;
       // @ts-ignore
       setPropertiesForVersion(applePayVersions[2], ApplePay.VERSION_4_SUPPORTED_NETWORKS);
     });
@@ -138,11 +156,15 @@ describe('ApplePay', () => {
     // then
     it(`should set proper networks when Apple Pay version is equal ${applePayVersions[1]}`, () => {
       // @ts-ignore
+      instance._paymentRequest.supportedNetworks = ApplePay.VERSION_5_SUPPORTED_NETWORKS;
+      // @ts-ignore
       setPropertiesForVersion(applePayVersions[1], ApplePay.BASIC_SUPPORTED_NETWORKS);
     });
 
     // then
     it(`should set proper networks when Apple Pay version is equal ${applePayVersions[0]}`, () => {
+      // @ts-ignore
+      instance._paymentRequest.supportedNetworks = ApplePay.VERSION_5_SUPPORTED_NETWORKS;
       // @ts-ignore
       setPropertiesForVersion(applePayVersions[0], ApplePay.BASIC_SUPPORTED_NETWORKS);
     });


### PR DESCRIPTION
We now use the supportedNetworks passed in by the merchant in the config to determine a subset of supportedNetworks based on what is supported by the device