### PR TITLE
Fix for missing . for class in dom selector

### DIFF
--- a/src/components/notification-frame/NotificationFrame.ts
+++ b/src/components/notification-frame/NotificationFrame.ts
@@ -64,9 +64,9 @@ export class NotificationFrame extends Frame {
     let allowed = super.getAllowedStyles();
     const notification = `#${NotificationFrame.ELEMENT_ID}`;
     const error = `.${NotificationFrame.ELEMENT_CLASSES.error}${notification}`;
-    const success = `${NotificationFrame.ELEMENT_CLASSES.success}${notification}`;
-    const warning = `${NotificationFrame.ELEMENT_CLASSES.warning}${notification}`;
-    const info = `${NotificationFrame.ELEMENT_CLASSES.info}${notification}`;
+    const success = `.${NotificationFrame.ELEMENT_CLASSES.success}${notification}`;
+    const warning = `.${NotificationFrame.ELEMENT_CLASSES.warning}${notification}`;
+    const info = `.${NotificationFrame.ELEMENT_CLASSES.info}${notification}`;
     allowed = {
       ...allowed,
       'background-color-notification': {


### PR DESCRIPTION
Fix after our documentation team spotted the following when documenting the styling:

Styling of the background of successful notifications doesn't seem to take effect but errors can be styled

The fix involves updating dom selector to include the . (dot) for class