### PR TITLE
Bugfix/st 453 block form after payment

### DIFF
--- a/src/components/card-number/CardNumber.ts
+++ b/src/components/card-number/CardNumber.ts
@@ -1,3 +1,4 @@
+import { FormState } from "../../core/models/constants/FormState";
 import { IFormFieldState } from '../../core/models/IFormFieldState';
 import { IMessageBusEvent } from '../../core/models/IMessageBusEvent';
 import { Formatter } from '../../core/shared/Formatter';
@@ -156,10 +157,9 @@ export class CardNumber extends FormField {
   }
 
   private _setDisableListener() {
-    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_CARD_NUMBER, (state: boolean) => {
-      if (state) {
-        // @ts-ignore
-        this._inputElement.setAttribute(CardNumber.DISABLED_ATTRIBUTE, state);
+    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_CARD_NUMBER, (state: FormState) => {
+      if (state!==FormState.AVAILABLE) {
+        this._inputElement.setAttribute(CardNumber.DISABLED_ATTRIBUTE, 'true');
         this._inputElement.classList.add(CardNumber.DISABLED_CLASS);
       } else {
         // @ts-ignore
@@ -172,8 +172,9 @@ export class CardNumber extends FormField {
   private _disableSecurityCodeField(cardNumber: string) {
     const number: string = Validation.clearNonDigitsChars(cardNumber);
     const isCardPiba: boolean = CardNumber.NO_CVV_CARDS.includes(iinLookup.lookup(number).type);
+    const formState = isCardPiba ? FormState.PROCESSING : FormState.AVAILABLE;
     const messageBusEventPiba: IMessageBusEvent = {
-      data: isCardPiba,
+      data: formState,
       type: MessageBus.EVENTS.IS_CARD_WITHOUT_CVV
     };
     this.messageBus.publish(messageBusEventPiba);

--- a/src/components/card-number/CardNumber.ts
+++ b/src/components/card-number/CardNumber.ts
@@ -1,4 +1,4 @@
-import { FormState } from "../../core/models/constants/FormState";
+import { FormState } from '../../core/models/constants/FormState';
 import { IFormFieldState } from '../../core/models/IFormFieldState';
 import { IMessageBusEvent } from '../../core/models/IMessageBusEvent';
 import { Formatter } from '../../core/shared/Formatter';

--- a/src/components/card-number/CardNumber.ts
+++ b/src/components/card-number/CardNumber.ts
@@ -158,7 +158,7 @@ export class CardNumber extends FormField {
 
   private _setDisableListener() {
     this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_CARD_NUMBER, (state: FormState) => {
-      if (state!==FormState.AVAILABLE) {
+      if (state !== FormState.AVAILABLE) {
         this._inputElement.setAttribute(CardNumber.DISABLED_ATTRIBUTE, 'true');
         this._inputElement.classList.add(CardNumber.DISABLED_CLASS);
       } else {

--- a/src/components/card-number/CardNumber.ts
+++ b/src/components/card-number/CardNumber.ts
@@ -172,7 +172,7 @@ export class CardNumber extends FormField {
   private _disableSecurityCodeField(cardNumber: string) {
     const number: string = Validation.clearNonDigitsChars(cardNumber);
     const isCardPiba: boolean = CardNumber.NO_CVV_CARDS.includes(iinLookup.lookup(number).type);
-    const formState = isCardPiba ? FormState.PROCESSING : FormState.AVAILABLE;
+    const formState = isCardPiba ? FormState.BLOCKED : FormState.AVAILABLE;
     const messageBusEventPiba: IMessageBusEvent = {
       data: formState,
       type: MessageBus.EVENTS.IS_CARD_WITHOUT_CVV

--- a/src/components/control-frame/ControlFrame.ts
+++ b/src/components/control-frame/ControlFrame.ts
@@ -2,7 +2,7 @@ import JwtDecode from 'jwt-decode';
 import { StCodec } from '../../core/classes/StCodec.class';
 import { FormFieldsDetails } from '../../core/models/constants/FormFieldsDetails';
 import { FormFieldsValidity } from '../../core/models/constants/FormFieldsValidity';
-import { FormState } from "../../core/models/constants/FormState";
+import { FormState } from '../../core/models/constants/FormState';
 import { ICard } from '../../core/models/ICard';
 import { IDecodedJwt } from '../../core/models/IDecodedJwt';
 import { IFormFieldsDetails } from '../../core/models/IFormFieldsDetails';

--- a/src/components/control-frame/ControlFrame.ts
+++ b/src/components/control-frame/ControlFrame.ts
@@ -2,6 +2,7 @@ import JwtDecode from 'jwt-decode';
 import { StCodec } from '../../core/classes/StCodec.class';
 import { FormFieldsDetails } from '../../core/models/constants/FormFieldsDetails';
 import { FormFieldsValidity } from '../../core/models/constants/FormFieldsValidity';
+import { FormState } from "../../core/models/constants/FormState";
 import { ICard } from '../../core/models/ICard';
 import { IDecodedJwt } from '../../core/models/IDecodedJwt';
 import { IFormFieldsDetails } from '../../core/models/IFormFieldsDetails';
@@ -229,10 +230,11 @@ export class ControlFrame extends Frame {
       .processPayment(this._postThreeDRequestTypes, this._card, this._merchantFormData, data)
       .then(() => {
         this._notification.success(Language.translations.PAYMENT_SUCCESS);
+        this._validation.blockForm(FormState.COMPLETE);
       })
       .catch((error: any) => {
         this._notification.error(Language.translations.PAYMENT_ERROR);
-        this._validation.blockForm(false);
+        this._validation.blockForm(FormState.AVAILABLE);
       })
       .finally(() => {
         ControlFrame._resetJwt();

--- a/src/components/control-frame/ControlFrame.ts
+++ b/src/components/control-frame/ControlFrame.ts
@@ -232,9 +232,10 @@ export class ControlFrame extends Frame {
       })
       .catch((error: any) => {
         this._notification.error(Language.translations.PAYMENT_ERROR);
+        this._validation.blockForm(false);
       })
       .finally(() => {
-        this._validation.blockForm(false);
+        ControlFrame._resetJwt();
       });
   }
 

--- a/src/components/expiration-date/ExpirationDate.ts
+++ b/src/components/expiration-date/ExpirationDate.ts
@@ -1,3 +1,4 @@
+import { FormState } from "../../core/models/constants/FormState";
 import { IMessageBusEvent } from '../../core/models/IMessageBusEvent';
 import { Formatter } from '../../core/shared/Formatter';
 import { FormField } from '../../core/shared/FormField';
@@ -29,8 +30,8 @@ export class ExpirationDate extends FormField {
   }
 
   public setDisableListener() {
-    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_EXPIRATION_DATE, (state: boolean) => {
-      state ? this._disableInputField() : this._enableInputField();
+    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_EXPIRATION_DATE, (state: FormState) => {
+      state!==FormState.AVAILABLE ? this._disableInputField() : this._enableInputField();
     });
   }
 

--- a/src/components/expiration-date/ExpirationDate.ts
+++ b/src/components/expiration-date/ExpirationDate.ts
@@ -31,7 +31,7 @@ export class ExpirationDate extends FormField {
 
   public setDisableListener() {
     this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_EXPIRATION_DATE, (state: FormState) => {
-      state!==FormState.AVAILABLE ? this._disableInputField() : this._enableInputField();
+      state !== FormState.AVAILABLE ? this._disableInputField() : this._enableInputField();
     });
   }
 

--- a/src/components/expiration-date/ExpirationDate.ts
+++ b/src/components/expiration-date/ExpirationDate.ts
@@ -1,4 +1,4 @@
-import { FormState } from "../../core/models/constants/FormState";
+import { FormState } from '../../core/models/constants/FormState';
 import { IMessageBusEvent } from '../../core/models/IMessageBusEvent';
 import { Formatter } from '../../core/shared/Formatter';
 import { FormField } from '../../core/shared/FormField';

--- a/src/components/notification-frame/NotificationFrame.ts
+++ b/src/components/notification-frame/NotificationFrame.ts
@@ -174,7 +174,9 @@ export class NotificationFrame extends Frame {
     if (this.notificationFrameElement && notificationElementClass) {
       this.notificationFrameElement.classList.add(notificationElementClass);
       this._setDataNotificationColorAttribute(this._message.type);
-      this._autoHide(notificationElementClass);
+      if (this._message.type !== NotificationFrame.MESSAGE_TYPES.success) {
+        this._autoHide(notificationElementClass);
+      }
     }
   }
 

--- a/src/components/security-code/SecurityCode.ts
+++ b/src/components/security-code/SecurityCode.ts
@@ -131,7 +131,7 @@ export class SecurityCode extends FormField {
     });
 
     this.messageBus.subscribe(MessageBus.EVENTS.IS_CARD_WITHOUT_CVV, (state: FormState) => {
-      if (state!==FormState.AVAILABLE) {
+      if (state !== FormState.AVAILABLE) {
         this._clearInputValue();
       }
       this._toggleSecurityCode(state);

--- a/src/components/security-code/SecurityCode.ts
+++ b/src/components/security-code/SecurityCode.ts
@@ -1,10 +1,11 @@
-import { IMessageBusEvent } from '../../core/models/IMessageBusEvent';
-import { Formatter } from '../../core/shared/Formatter';
-import { FormField } from '../../core/shared/FormField';
-import { Language } from '../../core/shared/Language';
-import { MessageBus } from '../../core/shared/MessageBus';
-import { Selectors } from '../../core/shared/Selectors';
-import { Validation } from '../../core/shared/Validation';
+import { FormState } from "../../core/models/constants/FormState";
+import { IMessageBusEvent } from "../../core/models/IMessageBusEvent";
+import { Formatter } from "../../core/shared/Formatter";
+import { FormField } from "../../core/shared/FormField";
+import { Language } from "../../core/shared/Language";
+import { MessageBus } from "../../core/shared/MessageBus";
+import { Selectors } from "../../core/shared/Selectors";
+import { Validation } from "../../core/shared/Validation";
 
 export class SecurityCode extends FormField {
   public static ifFieldExists = (): HTMLInputElement =>
@@ -102,7 +103,7 @@ export class SecurityCode extends FormField {
   }
 
   private _setDisableListener() {
-    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_SECURITY_CODE, (state: boolean) => {
+    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_SECURITY_CODE, (state: FormState) => {
       this._toggleSecurityCode(state);
     });
   }
@@ -129,8 +130,8 @@ export class SecurityCode extends FormField {
       this._sendState();
     });
 
-    this.messageBus.subscribe(MessageBus.EVENTS.IS_CARD_WITHOUT_CVV, (state: boolean) => {
-      if (state) {
+    this.messageBus.subscribe(MessageBus.EVENTS.IS_CARD_WITHOUT_CVV, (state: FormState) => {
+      if (state!==FormState.AVAILABLE) {
         this._clearInputValue();
       }
       this._toggleSecurityCode(state);
@@ -160,8 +161,8 @@ export class SecurityCode extends FormField {
     this.setAttributes({ pattern: securityCodePattern });
   }
 
-  private _toggleSecurityCode(disabled: boolean) {
-    if (disabled) {
+  private _toggleSecurityCode(state: FormState) {
+    if (state !== FormState.AVAILABLE) {
       this._disableSecurityCode();
       this._toggleSecurityCodeValidation();
     } else {

--- a/src/components/security-code/SecurityCode.ts
+++ b/src/components/security-code/SecurityCode.ts
@@ -1,11 +1,11 @@
-import { FormState } from "../../core/models/constants/FormState";
-import { IMessageBusEvent } from "../../core/models/IMessageBusEvent";
-import { Formatter } from "../../core/shared/Formatter";
-import { FormField } from "../../core/shared/FormField";
-import { Language } from "../../core/shared/Language";
-import { MessageBus } from "../../core/shared/MessageBus";
-import { Selectors } from "../../core/shared/Selectors";
-import { Validation } from "../../core/shared/Validation";
+import { FormState } from '../../core/models/constants/FormState';
+import { IMessageBusEvent } from '../../core/models/IMessageBusEvent';
+import { Formatter } from '../../core/shared/Formatter';
+import { FormField } from '../../core/shared/FormField';
+import { Language } from '../../core/shared/Language';
+import { MessageBus } from '../../core/shared/MessageBus';
+import { Selectors } from '../../core/shared/Selectors';
+import { Validation } from '../../core/shared/Validation';
 
 export class SecurityCode extends FormField {
   public static ifFieldExists = (): HTMLInputElement =>

--- a/src/core/classes/CardFrames.class.ts
+++ b/src/core/classes/CardFrames.class.ts
@@ -328,7 +328,7 @@ export class CardFrames extends RegisterFrames {
 
   private _setSubmitButtonProperties(element: any, state: FormState): HTMLElement {
     let disabledState;
-    if (state === FormState.PROCESSING) {
+    if (state === FormState.BLOCKED) {
       element.textContent = this._processingMessage;
       element.classList.add(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS);
       disabledState = true;

--- a/src/core/classes/CardFrames.class.ts
+++ b/src/core/classes/CardFrames.class.ts
@@ -1,6 +1,6 @@
 import JwtDecode from 'jwt-decode';
 import { BypassCards } from '../models/constants/BypassCards';
-import { FormState } from "../models/constants/FormState";
+import { FormState } from '../models/constants/FormState';
 import { IMessageBusEvent } from '../models/IMessageBusEvent';
 import { IStyles } from '../models/IStyles';
 import { IValidationMessageBus } from '../models/IValidationMessageBus';

--- a/src/core/classes/CardFrames.class.ts
+++ b/src/core/classes/CardFrames.class.ts
@@ -1,5 +1,6 @@
 import JwtDecode from 'jwt-decode';
 import { BypassCards } from '../models/constants/BypassCards';
+import { FormState } from "../models/constants/FormState";
 import { IMessageBusEvent } from '../models/IMessageBusEvent';
 import { IStyles } from '../models/IStyles';
 import { IValidationMessageBus } from '../models/IValidationMessageBus';
@@ -174,7 +175,7 @@ export class CardFrames extends RegisterFrames {
     }
   }
 
-  private _disableFormField(state: boolean, eventName: string): void {
+  private _disableFormField(state: FormState, eventName: string): void {
     const messageBusEvent: IMessageBusEvent = {
       data: state,
       type: eventName
@@ -182,7 +183,7 @@ export class CardFrames extends RegisterFrames {
     this.messageBus.publish(messageBusEvent);
   }
 
-  private _disableSubmitButton(state: boolean): void {
+  private _disableSubmitButton(state: FormState): void {
     const button: HTMLButtonElement | HTMLInputElement = document.getElementById(this._buttonId) as
       | HTMLButtonElement
       | HTMLInputElement;
@@ -325,13 +326,22 @@ export class CardFrames extends RegisterFrames {
     this._loadAnimatedCard = loadAnimatedCard !== undefined ? loadAnimatedCard : true;
   }
 
-  private _setSubmitButtonProperties(element: any, disabledState: boolean): HTMLElement {
-    if (disabledState) {
+  private _setSubmitButtonProperties(element: any, state: FormState): HTMLElement {
+    let disabledState;
+    if (state === FormState.PROCESSING) {
       element.textContent = this._processingMessage;
       element.classList.add(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS);
-    } else {
+      disabledState = true;
+    }
+    else if (state === FormState.COMPLETE) {
+      element.textContent = this._payMessage;
+      element.classList.add(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS); // Keep it locked but return it to original text
+      disabledState = true;
+    }
+    else {
       element.textContent = this._payMessage;
       element.classList.remove(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS);
+      disabledState = false;
     }
     element.disabled = disabledState;
     return element;
@@ -347,7 +357,7 @@ export class CardFrames extends RegisterFrames {
   }
 
   private _subscribeBlockSubmit(): void {
-    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_FORM, (state: boolean) => {
+    this.messageBus.subscribe(MessageBus.EVENTS.BLOCK_FORM, (state: FormState) => {
       this._disableSubmitButton(state);
       this._disableFormField(state, MessageBus.EVENTS.BLOCK_CARD_NUMBER);
       this._disableFormField(state, MessageBus.EVENTS.BLOCK_EXPIRATION_DATE);

--- a/src/core/classes/CommonFrames.class.ts
+++ b/src/core/classes/CommonFrames.class.ts
@@ -1,4 +1,5 @@
 import { CardinalCommerce } from '../integrations/CardinalCommerce';
+import { FormState } from "../models/constants/FormState";
 import { IStyles } from '../models/IStyles';
 import { Element } from '../services/Element';
 import { DomMethods } from '../shared/DomMethods';
@@ -147,7 +148,7 @@ export class CommonFrames extends RegisterFrames {
 
   private _onTransactionComplete(data: any) {
     if ((this._isTransactionFinished(data) || data.errorcode !== '0') && this._submitCallback) {
-      this._validation.blockForm(false);
+      this._validation.blockForm(FormState.AVAILABLE);
       this._submitCallback(data);
     }
     if (this._shouldSubmitForm(data)) {

--- a/src/core/classes/CommonFrames.class.ts
+++ b/src/core/classes/CommonFrames.class.ts
@@ -1,5 +1,5 @@
 import { CardinalCommerce } from '../integrations/CardinalCommerce';
-import { FormState } from "../models/constants/FormState";
+import { FormState } from '../models/constants/FormState';
 import { IStyles } from '../models/IStyles';
 import { Element } from '../services/Element';
 import { DomMethods } from '../shared/DomMethods';

--- a/src/core/classes/StCodec.class.ts
+++ b/src/core/classes/StCodec.class.ts
@@ -1,14 +1,15 @@
-import JwtDecode from 'jwt-decode';
-import { IMessageBusEvent } from '../models/IMessageBusEvent';
-import { IResponseData } from '../models/IResponseData';
-import { IStRequest } from '../models/IStRequest';
-import { Language } from '../shared/Language';
-import { MessageBus } from '../shared/MessageBus';
-import { Notification } from '../shared/Notification';
-import { Selectors } from '../shared/Selectors';
-import { StJwt } from '../shared/StJwt';
-import { Translator } from '../shared/Translator';
-import { Validation } from '../shared/Validation';
+import JwtDecode from "jwt-decode";
+import { FormState } from "../models/constants/FormState";
+import { IMessageBusEvent } from "../models/IMessageBusEvent";
+import { IResponseData } from "../models/IResponseData";
+import { IStRequest } from "../models/IStRequest";
+import { Language } from "../shared/Language";
+import { MessageBus } from "../shared/MessageBus";
+import { Notification } from "../shared/Notification";
+import { Selectors } from "../shared/Selectors";
+import { StJwt } from "../shared/StJwt";
+import { Translator } from "../shared/Translator";
+import { Validation } from "../shared/Validation";
 
 class StCodec {
   public static CONTENT_TYPE = 'application/json';
@@ -129,7 +130,7 @@ class StCodec {
     const validation = new Validation();
     StCodec.publishResponse(StCodec._createCommunicationError());
     StCodec._notification.error(Language.translations.COMMUNICATION_ERROR_INVALID_RESPONSE);
-    validation.blockForm(false);
+    validation.blockForm(FormState.AVAILABLE);
     return new Error(Language.translations.COMMUNICATION_ERROR_INVALID_RESPONSE);
   }
 
@@ -164,7 +165,7 @@ class StCodec {
         if (responseContent.errorcode === StCodec.STATUS_CODES.invalidfield) {
           validation.getErrorData(StCodec.getErrorData(responseContent));
         }
-        validation.blockForm(false);
+        validation.blockForm(FormState.AVAILABLE);
         StCodec.publishResponse(responseContent, jwtResponse);
         StCodec._notification.error(responseContent.errormessage);
         throw new Error(responseContent.errormessage);

--- a/src/core/classes/StCodec.class.ts
+++ b/src/core/classes/StCodec.class.ts
@@ -1,15 +1,15 @@
-import JwtDecode from "jwt-decode";
-import { FormState } from "../models/constants/FormState";
-import { IMessageBusEvent } from "../models/IMessageBusEvent";
-import { IResponseData } from "../models/IResponseData";
-import { IStRequest } from "../models/IStRequest";
-import { Language } from "../shared/Language";
-import { MessageBus } from "../shared/MessageBus";
-import { Notification } from "../shared/Notification";
-import { Selectors } from "../shared/Selectors";
-import { StJwt } from "../shared/StJwt";
-import { Translator } from "../shared/Translator";
-import { Validation } from "../shared/Validation";
+import JwtDecode from 'jwt-decode';
+import { FormState } from '../models/constants/FormState';
+import { IMessageBusEvent } from '../models/IMessageBusEvent';
+import { IResponseData } from '../models/IResponseData';
+import { IStRequest } from '../models/IStRequest';
+import { Language } from '../shared/Language';
+import { MessageBus } from '../shared/MessageBus';
+import { Notification } from '../shared/Notification';
+import { Selectors } from '../shared/Selectors';
+import { StJwt } from '../shared/StJwt';
+import { Translator } from '../shared/Translator';
+import { Validation } from '../shared/Validation';
 
 class StCodec {
   public static CONTENT_TYPE = 'application/json';

--- a/src/core/models/constants/FormState.ts
+++ b/src/core/models/constants/FormState.ts
@@ -1,0 +1,5 @@
+export enum FormState {
+  PROCESSING = 'PROCESSING',
+  AVAILABLE = 'AVAILABLE',
+  COMPLETE = 'COMPLETE'
+}

--- a/src/core/models/constants/FormState.ts
+++ b/src/core/models/constants/FormState.ts
@@ -1,5 +1,5 @@
 export enum FormState {
-  PROCESSING = 'PROCESSING',
+  BLOCKED = 'BLOCKED',
   AVAILABLE = 'AVAILABLE',
   COMPLETE = 'COMPLETE'
 }

--- a/src/core/shared/Validation.ts
+++ b/src/core/shared/Validation.ts
@@ -1,20 +1,20 @@
-import { iinLookup } from "@securetrading/ts-iin-lookup";
-import { BrandDetailsType } from "@securetrading/ts-iin-lookup/dist/types";
-import { luhnCheck } from "@securetrading/ts-luhn-check";
-import { StCodec } from "../classes/StCodec.class";
-import { FormState } from "../models/constants/FormState";
-import { ICard } from "../models/ICard";
-import { IErrorData } from "../models/IErrorData";
-import { IFormFieldState } from "../models/IFormFieldState";
-import { IMessageBusEvent } from "../models/IMessageBusEvent";
-import { IMessageBusValidateField } from "../models/IMessageBusValidateField";
-import { IValidation } from "../models/IValidation";
-import { Frame } from "./Frame";
-import { Language } from "./Language";
-import { MessageBus } from "./MessageBus";
-import { Selectors } from "./Selectors";
-import { Translator } from "./Translator";
-import { Utils } from "./Utils";
+import { iinLookup } from '@securetrading/ts-iin-lookup';
+import { BrandDetailsType } from '@securetrading/ts-iin-lookup/dist/types';
+import { luhnCheck } from '@securetrading/ts-luhn-check';
+import { StCodec } from '../classes/StCodec.class';
+import { FormState } from '../models/constants/FormState';
+import { ICard } from '../models/ICard';
+import { IErrorData } from '../models/IErrorData';
+import { IFormFieldState } from '../models/IFormFieldState';
+import { IMessageBusEvent } from '../models/IMessageBusEvent';
+import { IMessageBusValidateField } from '../models/IMessageBusValidateField';
+import { IValidation } from '../models/IValidation';
+import { Frame } from './Frame';
+import { Language } from './Language';
+import { MessageBus } from './MessageBus';
+import { Selectors } from './Selectors';
+import { Translator } from './Translator';
+import { Utils } from './Utils';
 
 const {
   VALIDATION_ERROR_FIELD_IS_REQUIRED,

--- a/src/core/shared/Validation.ts
+++ b/src/core/shared/Validation.ts
@@ -1,19 +1,20 @@
-import { StCodec } from '../classes/StCodec.class';
-import { ICard } from '../models/ICard';
-import { IErrorData } from '../models/IErrorData';
-import { IFormFieldState } from '../models/IFormFieldState';
-import { IMessageBusEvent } from '../models/IMessageBusEvent';
-import { IMessageBusValidateField } from '../models/IMessageBusValidateField';
-import { IValidation } from '../models/IValidation';
-import { Frame } from './Frame';
-import { Language } from './Language';
-import { MessageBus } from './MessageBus';
-import { Selectors } from './Selectors';
-import { Translator } from './Translator';
-import { Utils } from './Utils';
-import { iinLookup } from '@securetrading/ts-iin-lookup';
-import { BrandDetailsType } from '@securetrading/ts-iin-lookup/dist/types';
-import { luhnCheck } from '@securetrading/ts-luhn-check';
+import { iinLookup } from "@securetrading/ts-iin-lookup";
+import { BrandDetailsType } from "@securetrading/ts-iin-lookup/dist/types";
+import { luhnCheck } from "@securetrading/ts-luhn-check";
+import { StCodec } from "../classes/StCodec.class";
+import { FormState } from "../models/constants/FormState";
+import { ICard } from "../models/ICard";
+import { IErrorData } from "../models/IErrorData";
+import { IFormFieldState } from "../models/IFormFieldState";
+import { IMessageBusEvent } from "../models/IMessageBusEvent";
+import { IMessageBusValidateField } from "../models/IMessageBusValidateField";
+import { IValidation } from "../models/IValidation";
+import { Frame } from "./Frame";
+import { Language } from "./Language";
+import { MessageBus } from "./MessageBus";
+import { Selectors } from "./Selectors";
+import { Translator } from "./Translator";
+import { Utils } from "./Utils";
 
 const {
   VALIDATION_ERROR_FIELD_IS_REQUIRED,
@@ -174,7 +175,7 @@ export class Validation extends Frame {
     });
   }
 
-  public blockForm(state: boolean) {
+  public blockForm(state: FormState) {
     const messageBusEvent: IMessageBusEvent = {
       data: state,
       type: MessageBus.EVENTS.BLOCK_FORM
@@ -204,7 +205,7 @@ export class Validation extends Frame {
     this._setValidationResult(dataInJwt, fieldsToSubmit, formFields, isPanPiba, paymentReady);
     const isFormReadyToSubmit: boolean = this._isFormReadyToSubmit(deferInit);
     if (isFormReadyToSubmit) {
-      this.blockForm(true);
+      this.blockForm(FormState.PROCESSING);
     }
     return {
       card: this._card,

--- a/src/core/shared/Validation.ts
+++ b/src/core/shared/Validation.ts
@@ -205,7 +205,7 @@ export class Validation extends Frame {
     this._setValidationResult(dataInJwt, fieldsToSubmit, formFields, isPanPiba, paymentReady);
     const isFormReadyToSubmit: boolean = this._isFormReadyToSubmit(deferInit);
     if (isFormReadyToSubmit) {
-      this.blockForm(FormState.PROCESSING);
+      this.blockForm(FormState.BLOCKED);
     }
     return {
       card: this._card,

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -5,7 +5,7 @@
   "deferInit": true,
   "fieldsToSubmit": ["pan", "expirydate", "securitycode"],
   "buttonId": "merchant-submit-button",
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhbTAzMTAuYXV0b2FwaSIsImlhdCI6MTU4MDgyMTgyMS43MzE2OTkyLCJwYXlsb2FkIjp7ImJhc2VhbW91bnQiOiIxMDAwIiwiYWNjb3VudHR5cGVkZXNjcmlwdGlvbiI6IkVDT00iLCJjdXJyZW5jeWlzbzNhIjoiR0JQIiwic2l0ZXJlZmVyZW5jZSI6InRlc3RfamFtZXMzODY0MSIsImxvY2FsZSI6ImVuX0dCIn19.3s0Taro8LbBxzPNaVUebQndzcJb9cfs7njPpjOfjyGU",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3ZWJzZXJ2aWNlc0BtZXJjaGFudC5jb20iLCJpYXQiOjE1ODA4NDE5NTMuMzg0MzA2NCwicGF5bG9hZCI6eyJiYXNlYW1vdW50IjoiMTAwMCIsImFjY291bnR0eXBlZGVzY3JpcHRpb24iOiJFQ09NIiwiY3VycmVuY3lpc28zYSI6IkdCUCIsInNpdGVyZWZlcmVuY2UiOiJ0ZXN0MSIsImxvY2FsZSI6ImVuX0dCIn19.aTO5mSKxpLDPZvJZG8KG8kBvy_z6xCGTtQYDQE5GvxA",
   "styles": {
     "defaultStyles": {
       "background-color-input": "AliceBlue"

--- a/test/components/card-number/CardNumber.spec.ts
+++ b/test/components/card-number/CardNumber.spec.ts
@@ -1,6 +1,7 @@
 import each from 'jest-each';
 import SpyInstance = jest.SpyInstance;
 import { CardNumber } from '../../../src/components/card-number/CardNumber';
+import { FormState } from "../../../src/core/models/constants/FormState";
 import { Selectors } from '../../../src/core/shared/Selectors';
 import { FormField } from '../../../src/core/shared/FormField';
 import { Utils } from '../../../src/core/shared/Utils';
@@ -181,7 +182,7 @@ describe('CardNumber', () => {
   describe('_setDisableListener()', () => {
     const { instance } = cardNumberFixture();
 
-    function subscribeMock(state: boolean) {
+    function subscribeMock(state: FormState) {
       // @ts-ignore
       instance.messageBus.subscribe = jest.fn().mockImplementation((event, callback) => {
         callback(state);
@@ -192,28 +193,28 @@ describe('CardNumber', () => {
 
     // then
     it('should set attribute disabled', () => {
-      subscribeMock(true);
+      subscribeMock(FormState.BLOCKED);
       // @ts-ignore
       expect(instance._inputElement.hasAttribute('disabled')).toEqual(true);
     });
 
     // then
     it('should add class st-input--disabled', () => {
-      subscribeMock(true);
+      subscribeMock(FormState.BLOCKED);
       // @ts-ignore
       expect(instance._inputElement.classList.contains('st-input--disabled')).toEqual(true);
     });
 
     // then
     it('should remove attribute disabled', () => {
-      subscribeMock(false);
+      subscribeMock(FormState.AVAILABLE);
       // @ts-ignore
       expect(instance._inputElement.hasAttribute('disabled')).toEqual(false);
     });
 
     // then
     it('should remove class st-input--disabled', () => {
-      subscribeMock(false);
+      subscribeMock(FormState.AVAILABLE);
       // @ts-ignore
       expect(instance._inputElement.classList.contains('st-input--disabled')).toEqual(false);
     });
@@ -473,7 +474,7 @@ describe('CardNumber', () => {
     const { instance } = cardNumberFixture();
     const pan: string = '3089 5000 0000 0000021';
     const messageBusEvent = {
-      data: true,
+      data: FormState.BLOCKED,
       type: MessageBus.EVENTS.IS_CARD_WITHOUT_CVV
     };
     Validation.clearNonDigitsChars = jest.fn().mockReturnValueOnce('3089500000000000021');

--- a/test/components/expiration-date/ExpirationDate.spec.ts
+++ b/test/components/expiration-date/ExpirationDate.spec.ts
@@ -1,4 +1,5 @@
 import { ExpirationDate } from '../../../src/components/expiration-date/ExpirationDate';
+import { FormState } from "../../../src/core/models/constants/FormState";
 import { Language } from '../../../src/core/shared/Language';
 import { Selectors } from '../../../src/core/shared/Selectors';
 
@@ -36,7 +37,7 @@ describe('ExpirationDate', () => {
     it('should have attribute disabled set', () => {
       // @ts-ignore
       instance.messageBus.subscribe = jest.fn().mockImplementation((event, callback) => {
-        callback(true);
+        callback(FormState.BLOCKED);
       });
       instance.setDisableListener();
       // @ts-ignore
@@ -47,7 +48,7 @@ describe('ExpirationDate', () => {
     it('should have no attribute disabled and class disabled', () => {
       // @ts-ignore
       instance.messageBus.subscribe = jest.fn().mockImplementation((event, callback) => {
-        callback(false);
+        callback(FormState.AVAILABLE);
       });
       instance.setDisableListener();
       // @ts-ignore

--- a/test/core/classes/CardFrames.spec.ts
+++ b/test/core/classes/CardFrames.spec.ts
@@ -1,9 +1,10 @@
-import { CardFrames } from '../../../src/core/classes/CardFrames.class';
-import { BypassCards } from '../../../src/core/models/constants/BypassCards';
-import { DomMethods } from '../../../src/core/shared/DomMethods';
-import { Language } from '../../../src/core/shared/Language';
-import { MessageBus } from '../../../src/core/shared/MessageBus';
-import { Selectors } from '../../../src/core/shared/Selectors';
+import { CardFrames } from "../../../src/core/classes/CardFrames.class";
+import { BypassCards } from "../../../src/core/models/constants/BypassCards";
+import { FormState } from "../../../src/core/models/constants/FormState";
+import { DomMethods } from "../../../src/core/shared/DomMethods";
+import { Language } from "../../../src/core/shared/Language";
+import { MessageBus } from "../../../src/core/shared/MessageBus";
+import { Selectors } from "../../../src/core/shared/Selectors";
 
 // given
 describe('CardFrames', () => {
@@ -290,9 +291,9 @@ describe('CardFrames', () => {
     const button = document.createElement('button');
     button.setAttribute('type', 'submit');
     // then
-    it('should mark button as disabled when disabledState is true', () => {
+    it('should mark button as disabled when form state is blocked', () => {
       // @ts-ignore
-      instance._setSubmitButtonProperties(button, true);
+      instance._setSubmitButtonProperties(button, FormState.BLOCKED);
       expect(button.textContent).toEqual(`${Language.translations.PROCESSING} ...`);
       // @ts-ignore
       expect(button.classList.contains(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS)).toEqual(true);
@@ -300,9 +301,19 @@ describe('CardFrames', () => {
     });
 
     // then
-    it('should remove disabled attributes from button when disabledState is false', () => {
+    it('should mark button as disabled when form state is complete but text should be pay', () => {
       // @ts-ignore
-      instance._setSubmitButtonProperties(button, false);
+      instance._setSubmitButtonProperties(button, FormState.COMPLETE);
+      expect(button.textContent).toEqual(Language.translations.PAY);
+      // @ts-ignore
+      expect(button.classList.contains(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS)).toEqual(true);
+      expect(button.disabled).toEqual(true);
+    });
+
+    // then
+    it('should remove disabled attributes from button when form state is available', () => {
+      // @ts-ignore
+      instance._setSubmitButtonProperties(button, FormState.AVAILABLE);
       expect(button.textContent).toEqual(Language.translations.PAY);
       // @ts-ignore
       expect(button.classList.contains(CardFrames.SUBMIT_BUTTON_DISABLED_CLASS)).toEqual(false);

--- a/test/core/shared/Validation.spec.ts
+++ b/test/core/shared/Validation.spec.ts
@@ -1,8 +1,9 @@
-import each from 'jest-each';
-import { MessageBus } from '../../../src/core/shared/MessageBus';
-import { Validation } from '../../../src/core/shared/Validation';
-import { Language } from '../../../src/core/shared/Language';
-import { StCodec } from '../../../src/core/classes/StCodec.class';
+import each from "jest-each";
+import { StCodec } from "../../../src/core/classes/StCodec.class";
+import { FormState } from "../../../src/core/models/constants/FormState";
+import { Language } from "../../../src/core/shared/Language";
+import { MessageBus } from "../../../src/core/shared/MessageBus";
+import { Validation } from "../../../src/core/shared/Validation";
 
 jest.mock('./../../../src/core/shared/MessageBus');
 
@@ -43,16 +44,16 @@ describe('Validation', () => {
   });
 
   // given
-  describe('blockForm()', () => {
+  describe('blockForm()', () => { // TODO FormState.COMPLETE
     const { instance } = validationFixture();
     // then
     it('should return state of blocking action equals true if MessageBus event data is true', () => {
-      expect(instance.blockForm(true)).toBe(undefined);
+      expect(instance.blockForm(FormState.PROCESSING)).toBe(undefined);
     });
 
     // then
     it('should return state of blocking action equals false if MessageBus event data is false', () => {
-      expect(instance.blockForm(false)).toBe(undefined);
+      expect(instance.blockForm(FormState.AVAILABLE)).toBe(undefined);
     });
   });
 

--- a/test/core/shared/Validation.spec.ts
+++ b/test/core/shared/Validation.spec.ts
@@ -47,12 +47,17 @@ describe('Validation', () => {
   describe('blockForm()', () => { // TODO FormState.COMPLETE
     const { instance } = validationFixture();
     // then
-    it('should return state of blocking action equals true if MessageBus event data is true', () => {
-      expect(instance.blockForm(FormState.PROCESSING)).toBe(undefined);
+    it('should return state of blocking action equals blocked if MessageBus event data is true', () => {
+      expect(instance.blockForm(FormState.BLOCKED)).toBe(undefined);
     });
 
     // then
-    it('should return state of blocking action equals false if MessageBus event data is false', () => {
+    it('should return state of blocking action equals complete if MessageBus event data is true', () => {
+      expect(instance.blockForm(FormState.COMPLETE)).toBe(undefined);
+    });
+
+    // then
+    it('should return state of blocking action equals available if MessageBus event data is false', () => {
       expect(instance.blockForm(FormState.AVAILABLE)).toBe(undefined);
     });
   });


### PR DESCRIPTION
Additional functionality changes to prevent customers processing duplicate payments:
1) Form will now be permanently blocked after successful payment (can't process two transactions with the same payment form)
2) Form button will remain disabled after successful payment but display "Pay"
3) Success message will remain indefinitely (all other messages will keep current behaviour of disappearing after 5seconds) 