### PR TITLE
Hotfix/localstorage in incognito in an iframe

### DIFF
--- a/src/core/models/constants/ConfigSchema.ts
+++ b/src/core/models/constants/ConfigSchema.ts
@@ -78,21 +78,7 @@ export const ConfigSchema: Joi.JoiObject = Joi.object().keys({
   ),
   styles: Joi.object(),
   submitCallback: Joi.any(),
-  submitFields: Joi.array().items(
-    Joi.string().valid(
-      'baseamount',
-      'currencyiso3a',
-      'eci',
-      'enrolled',
-      'errorcode',
-      'errordata',
-      'errormessage',
-      'orderreference',
-      'settlestatus',
-      'status',
-      'transactionreference'
-    )
-  ),
+  submitFields: Joi.array(),
   submitOnError: Joi.boolean(),
   submitOnSuccess: Joi.boolean(),
   threedinit: Joi.string(),

--- a/src/core/shared/Translator.ts
+++ b/src/core/shared/Translator.ts
@@ -48,9 +48,11 @@ export class Translator {
 
   public translate = (text: string) => {
     const translations: string = this._storage.getItem('merchantTranslations');
-    const json: string = JSON.parse(translations);
-    // @ts-ignore
-    const translation: string = Object.keys(json).includes(text) ? json[text] : '';
-    return translation ? translation : i18next.t(text, { content: text });
+    if (translations!==null) {
+      const json: string = JSON.parse(translations);
+      // @ts-ignore
+      const translation: string = Object.keys(json).includes(text) ? json[text] : '';
+      return translation ? translation : i18next.t(text, { content: text });
+    }
   };
 }


### PR DESCRIPTION
There seems to be some very odd behaviour if we use chrome in incognito mode with a merchant page inside an iframe where the localStorage isn't set or doesn't allow cross-origin or something.

As a quick work around I have added a check into Translator to check if the local storage exists for merchantTranslations and not to crash if it doesn't. But we should have a proper look into this to see why it isn't allowing localstorage in this case.

Also I have reverted the change to validate the submitFields as a merchant can ask for anything not just those that we default to e.g. they could ask for settleduedate which isn't in our list. So we can only validate that its an array for this one 