### PR TITLE
use try/catch for configurationInit

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -105,10 +105,10 @@
             return response.json();
           })
           .then(function(data) {
-            if (data) {
+            try {
               configurationInit(ST, data);
-            } else {
-              fetchDefaultConfig();
+            } catch (e) {
+              console.error(e);
             }
           })
           .catch(function() {


### PR DESCRIPTION
There was problem with getting mock config with invalid values, like:
"components": {
  "requestTypes": ["Test"]
},
This mock config was omitted and replaced by default config from the app