### PR TITLE
ST-564 - Add versioninfo to request to gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Notification frame styling issues.
 - Potential XSS vulnerability if a merchant site is vulnerable to XSS and passes un-sanitized values into the styling option. 
   - Additional sanitization used and insertRule used to prevent rules not whitelisted.
+  
+### Added
 - Added version info to request to gateway to allow ST to monitor what version the merchant is using
 
 ## 2.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Notification frame styling issues.
+- Potential XSS vulnerability if a merchant site is vulnerable to XSS and passes un-sanitized values into the styling option. 
+  - Additional sanitization used and insertRule used to prevent rules not whitelisted.
+- Added version info to request to gateway to allow ST to monitor what version the merchant is using
 
 ## 2.0.5
 

--- a/src/core/classes/StCodec.class.ts
+++ b/src/core/classes/StCodec.class.ts
@@ -10,10 +10,12 @@ import { Selectors } from '../shared/Selectors';
 import { StJwt } from '../shared/StJwt';
 import { Translator } from '../shared/Translator';
 import { Validation } from '../shared/Validation';
+import { version } from '../../../package.json';
 
 class StCodec {
   public static CONTENT_TYPE = 'application/json';
   public static VERSION = '1.00';
+  public static VERSION_INFO = `STJS::N/A::${ version }::N/A`;
   public static SUPPORTED_REQUEST_TYPES = [
     'WALLETVERIFY',
     'JSINIT',
@@ -208,7 +210,8 @@ class StCodec {
           sitereference: new StJwt(StCodec.jwt).sitereference
         }
       ],
-      version: StCodec.VERSION
+      version: StCodec.VERSION,
+      versioninfo: StCodec.VERSION_INFO
     };
   }
 

--- a/test/core/classes/StCodec.spec.ts
+++ b/test/core/classes/StCodec.spec.ts
@@ -379,6 +379,7 @@ describe('StCodec class', () => {
     // when
     beforeEach(() => {
       str = new StCodec(jwt);
+      StCodec.VERSION_INFO = 'STJS::N/A::2.0.0::N/A';
       // @ts-ignore
       StCodec.publishResponse = jest.fn();
     });
@@ -401,7 +402,8 @@ describe('StCodec class', () => {
         acceptcustomeroutput: '1.00',
         jwt,
         request: [{ requestid, ...expected }],
-        version: StCodec.VERSION
+        version: StCodec.VERSION,
+        versioninfo: 'STJS::N/A::2.0.0::N/A'
       });
     });
   });
@@ -411,6 +413,7 @@ describe('StCodec class', () => {
     // when
     beforeEach(() => {
       str = new StCodec(jwt);
+      StCodec.VERSION_INFO = 'STJS::N/A::2.0.0::N/A';
       // @ts-ignore
       StCodec.publishResponse = jest.fn();
     });
@@ -425,7 +428,7 @@ describe('StCodec class', () => {
               jwt +
               '","request":\\[{"pan":"4111111111111111","requesttypedescriptions":\\["AUTH"\\],"requestid":"' +
               ridRegex +
-              '","sitereference":"live2"}\\],"version":"1.00"}$'
+              '","sitereference":"live2"}\\],"version":"1.00","versioninfo":"STJS::N/A::2.0.0::N/A"}$'
           )
         )
       ],
@@ -438,7 +441,7 @@ describe('StCodec class', () => {
               '","request":\\[{"pan":"4111111111111111",' +
               '"requesttypedescriptions":\\["AUTH","SUBSCRIPTION"\\],"requestid":"' +
               ridRegex +
-              '","sitereference":"live2"}\\],"version":"1.00"}$'
+              '","sitereference":"live2"}\\],"version":"1.00","versioninfo":"STJS::N/A::2.0.0::N/A"}$'
           )
         )
       ]


### PR DESCRIPTION
Added a quick improvement to send the versioninfo in the server calls to ST so we can better debug if a merchant is using an old version