### PR TITLE
STJS-592 - Revert out of frictionless fix to fix updateJWT for currency change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.9
+
+### Fixed
+
+- Fix to ensure updateJWT works when changing currency from original JWT
+
 ## 2.0.8
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-payments",
-  "version": "2.0.7",
+  "version": "2.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-payments",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "> A JavaScript interface for allowing tokenisation and authorisation of payments through SecureTrading.",
   "private": true,
   "browserslist": [

--- a/src/core/shared/Payment.ts
+++ b/src/core/shared/Payment.ts
@@ -56,12 +56,7 @@ export class Payment {
         payload: { jwt, response }
       } = new StJwt(result.jwt);
       const threeDInitResult = { jwt, response: response[0] };
-      // We should always use the id from the original cachetoken to link up with the THREEDQUERY
-      // We've already passed this into Cardinal and they have used it for the fingerprint by this point
-      if (this._cardinalCommerceCacheToken === undefined) {
-        // @ts-ignore
-        this._cardinalCommerceCacheToken = result.response.cachetoken;
-      }
+      this._cardinalCommerceCacheToken = result.response.cachetoken;
       return threeDInitResult;
     });
   }


### PR DESCRIPTION
As described in Jira STJS-592 this change is to revert out of the fix that ensured frictionless 3DS2 cases worked with updateJWT as it caused a bigger issue where the updateJWT couldn't be used to convert between different currencies. A merchant is currently relying on this behaviour so needs to have this fixed. Another task STJS-593 has been added to provide a more robust fix for this original issue.

Steps to reproduce issue with changing JWT currency:
1. Create a JWT with GBP 10.00
2. Create a JWT with USD 20.00
3. Change JWT in config.json to one of the above and JWT in example/index.html updateJWT function call to the other
4. Enter text into the amount field on the example page to trigger the amount change and process a payment
5. The expected behaviour is to process a successful payment, but before this change, we are getting cannot change currency error 