### PR TITLE
STJS-595 - Fix ApplePay publish event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix to ensure updateJWT works when changing currency from original JWT
+- Update StCodec to always publish to parent
+- Update ApplePay successCallback to be called on success
 
 ## 2.0.8
 

--- a/src/components/control-frame/ControlFrame.ts
+++ b/src/components/control-frame/ControlFrame.ts
@@ -404,7 +404,7 @@ export class ControlFrame extends Frame {
   }
 
   private _setInstances(): void {
-    this._payment = new Payment(this.params.jwt, this.params.gatewayUrl, this.params.origin);
+    this._payment = new Payment(this.params.jwt, this.params.gatewayUrl);
     this._validation = new Validation();
   }
 

--- a/src/core/classes/CommonFrames.class.ts
+++ b/src/core/classes/CommonFrames.class.ts
@@ -162,7 +162,7 @@ export class CommonFrames extends RegisterFrames {
           if (localStore === 'true') {
             this._onTransactionComplete(data);
           }
-        }, 3000);
+        }, 500);
       } else {
         this._onTransactionComplete(data);
       }

--- a/src/core/classes/StCodec.class.ts
+++ b/src/core/classes/StCodec.class.ts
@@ -85,11 +85,7 @@ class StCodec {
       data: eventData,
       type: MessageBus.EVENTS_PUBLIC.TRANSACTION_COMPLETE
     };
-    if (StCodec._parentOrigin !== undefined) {
-      StCodec.getMessageBus().publish(notificationEvent, true);
-    } else {
-      StCodec.getMessageBus().publish(notificationEvent);
-    }
+    StCodec.getMessageBus().publish(notificationEvent, true);
   }
 
   public static updateJWTValue(newJWT: string) {
@@ -107,7 +103,6 @@ class StCodec {
   private static _notification: NotificationService;
   private static _messageBus: MessageBus;
   private static _locale: string;
-  private static _parentOrigin: string;
   private static REQUESTS_WITH_ERROR_MESSAGES = [
     'AUTH',
     'CACHETOKENISE',
@@ -198,13 +193,12 @@ class StCodec {
 
   private readonly _requestId: string;
 
-  constructor(jwt: string, parentOrigin?: string) {
+  constructor(jwt: string) {
     this._requestId = StCodec._createRequestId();
     StCodec._notification = Container.get(NotificationService);
     StCodec.jwt = jwt;
     StCodec.originalJwt = jwt;
     StCodec._locale = new StJwt(StCodec.jwt).locale;
-    StCodec._parentOrigin = parentOrigin;
   }
 
   public buildRequestObject(requestData: object): object {

--- a/src/core/classes/StTransport.class.ts
+++ b/src/core/classes/StTransport.class.ts
@@ -36,9 +36,9 @@ export class StTransport {
   private _gatewayUrl: string;
   private _throttlingRequests = new Map<string, Promise<object>>();
 
-  constructor(params: IStTransportParams, parentOrigin?: string) {
+  constructor(params: IStTransportParams) {
     this._gatewayUrl = params.gatewayUrl;
-    this._codec = new StCodec(params.jwt, parentOrigin);
+    this._codec = new StCodec(params.jwt);
   }
 
   /**

--- a/src/core/integrations/ApplePay.ts
+++ b/src/core/integrations/ApplePay.ts
@@ -1,4 +1,3 @@
-import { StTransport } from '../classes/StTransport.class';
 import { IWalletConfig } from '../config/model/IWalletConfig';
 import { DomMethods } from '../shared/DomMethods';
 import { Language } from '../shared/Language';
@@ -103,7 +102,6 @@ export class ApplePay {
   private _session: any;
   private _sitesecurity: string;
   private _stJwtInstance: StJwt;
-  private _stTransportInstance: StTransport;
 
   private _validateMerchantRequestData = {
     walletmerchantid: '',
@@ -192,10 +190,6 @@ export class ApplePay {
     this._requestTypes = requestTypes;
     this._validateMerchantRequestData.walletmerchantid = merchantId;
     this._stJwtInstance = new StJwt(jwt);
-    this._stTransportInstance = new StTransport({
-      gatewayUrl,
-      jwt
-    });
     this._translator = new Translator(this._stJwtInstance.locale);
     this._onInit(buttonText, buttonStyle);
   }
@@ -448,7 +442,7 @@ export class ApplePay {
 
   private _displayNotification(errorcode: string) {
     if (errorcode === '0') {
-      this._messageBus.publish({ type: MessageBus.EVENTS_PUBLIC.CALL_MERCHANT_ERROR_CALLBACK }, true);
+      this._messageBus.publish({ type: MessageBus.EVENTS_PUBLIC.CALL_MERCHANT_SUCCESS_CALLBACK }, true);
       this._notification.success(Language.translations.PAYMENT_SUCCESS);
     } else {
       this._messageBus.publish({ type: MessageBus.EVENTS_PUBLIC.CALL_MERCHANT_ERROR_CALLBACK }, true);

--- a/src/core/shared/Payment.ts
+++ b/src/core/shared/Payment.ts
@@ -19,9 +19,9 @@ export class Payment {
   private _validation: Validation;
   private readonly _walletVerifyRequest: IStRequest;
 
-  constructor(jwt: string, gatewayUrl: string, parentOrigin?: string) {
+  constructor(jwt: string, gatewayUrl: string) {
     this._notification = Container.get(NotificationService);
-    this._stTransport = new StTransport({ jwt, gatewayUrl }, parentOrigin);
+    this._stTransport = new StTransport({ jwt, gatewayUrl });
     this._validation = new Validation();
     this._walletVerifyRequest = {
       requesttypedescriptions: ['WALLETVERIFY']

--- a/test/core/classes/StCodec.spec.ts
+++ b/test/core/classes/StCodec.spec.ts
@@ -107,9 +107,7 @@ describe('StCodec class', () => {
     });
 
     // then
-    it('should translate and publish result to parent', () => {
-      // @ts-ignore
-      StCodec._parentOrigin = 'https://example.com';
+    it('should translate and publish result', () => {
       // @ts-ignore
       StCodec.publishResponse({
         errorcode: '0',
@@ -128,27 +126,6 @@ describe('StCodec class', () => {
         },
         true
       );
-    });
-
-    // then
-    it('should translate and publish result to itself', () => {
-      // @ts-ignore
-      StCodec._parentOrigin = undefined;
-      // @ts-ignore
-      StCodec.publishResponse({
-        errorcode: '0',
-        errormessage: 'Ok'
-      });
-      // @ts-ignore
-      expect(translator.translate()).toEqual('Ok');
-      // @ts-ignore
-      expect(StCodec.getMessageBus().publish).toHaveBeenCalledWith({
-        data: {
-          errorcode: '0',
-          errormessage: 'Payment has been successfully processed'
-        },
-        type: 'TRANSACTION_COMPLETE'
-      });
     });
 
     // then
@@ -350,7 +327,7 @@ describe('StCodec class', () => {
   describe('StCodec._createRequestId', () => {
     // when
     beforeEach(() => {
-      str = new StCodec(jwt, 'https://example.com');
+      str = new StCodec(jwt);
     });
 
     // then


### PR DESCRIPTION
* Fix the publish to always publish to parent as it was not getting the parentOrigin set correctly, but we don't need it anymore
* Also removed the unnecessary argument
* Reduced timeout it takes to detect applypay is complete as the local storage shouldn't take longer than 500ms. 
* Fixed typo of event name which triggers the success callback rather than the error callback for ApplePay