### PR TITLE
STJS-619 enabled cybertonica by default and changed default api key

### DIFF
--- a/example/json/config.json
+++ b/example/json/config.json
@@ -37,7 +37,7 @@
     "paymentTypes": [],
     "startOnLoad": false
   },
-  "cybertonicaApiKey": "test",
+  "cybertonicaApiKey": "stfs",
   "datacenterurl": "",
   "deferInit": false,
   "disableNotification": false,

--- a/src/application/core/models/constants/config-resolver/DefaultConfig.ts
+++ b/src/application/core/models/constants/config-resolver/DefaultConfig.ts
@@ -40,5 +40,6 @@ export const DefaultConfig: IConfig = {
   submitOnSuccess: true,
   threedinit: '',
   translations: {},
-  visaCheckout: {}
+  visaCheckout: {},
+  cybertonicaApiKey: 'stfs'
 };

--- a/src/client/config/ConfigResolver.spec.ts
+++ b/src/client/config/ConfigResolver.spec.ts
@@ -281,7 +281,7 @@ function ConfigResolverFixture() {
       paymentTypes: [''],
       startOnLoad: false
     },
-    cybertonicaApiKey: '',
+    cybertonicaApiKey: 'stfs',
     datacenterurl: 'https://webservices.securetrading.net/jwt/',
     deferInit: false,
     disableNotification: false,

--- a/src/client/config/ConfigResolver.ts
+++ b/src/client/config/ConfigResolver.ts
@@ -29,7 +29,7 @@ export class ConfigResolver {
       cachetoken: this._getValueOrDefault(config.cachetoken, DefaultConfig.cachetoken),
       componentIds: this._setComponentIds(config.componentIds),
       components: this._setComponentsProperties(config.components),
-      cybertonicaApiKey: this._getValueOrDefault(config.cybertonicaApiKey, ''),
+      cybertonicaApiKey: this._resolveCybertonicaApiKey(config.cybertonicaApiKey),
       datacenterurl: this._getValueOrDefault(config.datacenterurl, DefaultConfig.datacenterurl),
       deferInit: this._getValueOrDefault(config.deferInit, DefaultConfig.deferInit),
       disableNotification: this._getValueOrDefault(config.disableNotification, DefaultConfig.disableNotification),
@@ -138,5 +138,13 @@ export class ConfigResolver {
       expirydate: this._getValueOrDefault(config.expirydate, DefaultPlaceholders.expirydate),
       securitycode: this._getValueOrDefault(config.securitycode, DefaultPlaceholders.securitycode)
     };
+  }
+
+  private _resolveCybertonicaApiKey(value: string): string {
+    if (value === '') {
+      return '';
+    }
+
+    return this._getValueOrDefault(value, DefaultConfig.cybertonicaApiKey);
   }
 }


### PR DESCRIPTION
I changed the behavior a bit because of the typing issue - if a merchant wants to disable the cybertonica he should set the api key value to an empty string instead of `false`