### PR TITLE
feature/STJS-622-remove-unused-properties-in-config

### DIFF
--- a/example/json/config.json
+++ b/example/json/config.json
@@ -23,7 +23,7 @@
   },
   "buttonId": "merchant-submit-button",
   "bypassCards": ["PIBA"],
-  "cachetoken": "",
+  "cancelCallback": null,
   "componentIds": {
     "animatedCard": "",
     "cardNumber": "",
@@ -41,6 +41,7 @@
   "datacenterurl": "",
   "deferInit": false,
   "disableNotification": false,
+  "errorCallback": null,
   "fieldsToSubmit": [
     "pan",
     "expirydate",
@@ -51,7 +52,7 @@
     "cachetoken": "",
     "threedinit": ""
   },
-  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhbTAzMTAuYXV0b2FwaSIsImlhdCI6MTU4NzcxMzQwMi43MTU0NjEsInBheWxvYWQiOnsiYmFzZWFtb3VudCI6IjEwMDAiLCJhY2NvdW50dHlwZWRlc2NyaXB0aW9uIjoiRUNPTSIsImN1cnJlbmN5aXNvM2EiOiJHQlAiLCJzaXRlcmVmZXJlbmNlIjoidGVzdF9qYW1lczM4NjQxIiwibG9jYWxlIjoiZW5fR0IifX0.GBVMiPCD0aU_szSslN7nX_Dr8dcXCrbPmPDPLBdp8RQ",
+  "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJhbTAzMTAuYXV0b2FwaSIsImlhdCI6MTU4ODA3MjE1MC41Njk4MTAyLCJwYXlsb2FkIjp7ImJhc2VhbW91bnQiOiIxMDAwIiwiYWNjb3VudHR5cGVkZXNjcmlwdGlvbiI6IkVDT00iLCJjdXJyZW5jeWlzbzNhIjoiR0JQIiwic2l0ZXJlZmVyZW5jZSI6InRlc3RfamFtZXMzODY0MSIsImxvY2FsZSI6ImVuX0dCIn19.0JoTWH4uDW6oOZJ850HTh3c-bdPlCSWiqI-nzDcoaJg",
   "livestatus": 0,
   "origin": "",
   "panIcon": true,
@@ -60,7 +61,6 @@
     "expirydate": "MM/YY",
     "securitycode": "***"
   },
-  "requestTypes": [],
   "styles": {
     "defaultStyles": {
       "background-color-input": "AliceBlue"
@@ -84,12 +84,12 @@
       "color-error": "#3358FF"
     }
   },
+  "submitCallback": null,
   "submitFields": [],
   "submitOnSuccess": false,
   "submitOnError": false,
   "submitOnCancel": true,
-  "submitCallback": "",
-  "threedinit": "",
+  "successCallback": null,
   "translations": {
     "An error occurred": "Wystąpił błąd"
   },

--- a/src/application/core/integrations/CardinalCommerce.ts
+++ b/src/application/core/integrations/CardinalCommerce.ts
@@ -56,7 +56,6 @@ export class CardinalCommerce {
     this._jwt = jwt;
     this._threedinit = threedinit;
     this._livestatus = livestatus;
-    this._cachetoken = cachetoken ? cachetoken : '';
     this._requestTypes = requestTypes;
     this._bypassCards = bypassCards;
     this.messageBus = Container.get(MessageBus);

--- a/src/application/core/models/constants/config-resolver/DefaultConfig.ts
+++ b/src/application/core/models/constants/config-resolver/DefaultConfig.ts
@@ -16,7 +16,6 @@ export const DefaultConfig: IConfig = {
   applePay: {},
   buttonId: '',
   bypassCards: [],
-  cachetoken: '',
   cancelCallback: null,
   componentIds: DefaultComponentsIds,
   components: DefaultComponents,
@@ -33,14 +32,12 @@ export const DefaultConfig: IConfig = {
   origin: window.location.origin,
   panIcon: false,
   placeholders: DefaultPlaceholders,
-  requestTypes: DefaultRequestTypes,
   styles: {},
   submitCallback: null,
   submitFields: DefaultSubmitFields,
   submitOnError: false,
   submitOnSuccess: true,
   successCallback: null,
-  threedinit: '',
   translations: {},
   visaCheckout: {}
 };

--- a/src/client/ST.ts
+++ b/src/client/ST.ts
@@ -74,6 +74,7 @@ class ST {
       this.off('error');
     }
   }
+
   set cancelCallback(callback: (event: IErrorEvent) => void) {
     if (callback) {
       this.on('cancel', callback);

--- a/src/client/config/ConfigResolver.spec.ts
+++ b/src/client/config/ConfigResolver.spec.ts
@@ -53,7 +53,6 @@ function ConfigResolverFixture() {
     buttonId: 'merchant-submit-button',
     // @ts-ignore
     bypassCards: ['PIBA'],
-    cachetoken: '',
     componentIds: {
       animatedCard: '',
       cardNumber: '',
@@ -87,7 +86,6 @@ function ConfigResolverFixture() {
       securitycode: '***'
     },
     panIcon: true,
-    requestTypes: [],
     styles: {
       defaultStyles: {
         'background-color-input': 'AliceBlue'
@@ -115,7 +113,6 @@ function ConfigResolverFixture() {
     submitOnSuccess: false,
     submitOnError: false,
     submitCallback: '',
-    threedinit: '',
     translations: {
       'An error occurred': 'Wystąpił błąd'
     },
@@ -160,7 +157,6 @@ function ConfigResolverFixture() {
     buttonId: 'merchant-submit-button',
     // @ts-ignore
     bypassCards: ['PIBA'],
-    cachetoken: '',
     cancelCallback: null,
     componentIds: {
       animatedCard: 'st-animated-card',
@@ -196,7 +192,6 @@ function ConfigResolverFixture() {
       securitycode: '***'
     },
     panIcon: true,
-    requestTypes: ['THREEDQUERY', 'AUTH'],
     styles: {
       defaultStyles: {
         'background-color-input': 'AliceBlue'
@@ -238,7 +233,6 @@ function ConfigResolverFixture() {
     submitOnError: false,
     submitCallback: null,
     successCallback: null,
-    threedinit: '',
     translations: {
       'An error occurred': 'Wystąpił błąd'
     },
@@ -269,7 +263,6 @@ function ConfigResolverFixture() {
     buttonId: '',
     // @ts-ignore
     bypassCards: [],
-    cachetoken: '',
     cancelCallback: null,
     componentIds: {
       animatedCard: 'st-animated-card',
@@ -304,7 +297,6 @@ function ConfigResolverFixture() {
       securitycode: ''
     },
     panIcon: false,
-    requestTypes: ['THREEDQUERY', 'AUTH'],
     styles: {},
     submitFields: [
       'baseamount',
@@ -324,7 +316,6 @@ function ConfigResolverFixture() {
     submitOnError: false,
     submitCallback: null,
     successCallback: null,
-    threedinit: '',
     translations: {},
     visaCheckout: {}
   };

--- a/src/client/config/ConfigResolver.ts
+++ b/src/client/config/ConfigResolver.ts
@@ -26,7 +26,6 @@ export class ConfigResolver {
       applePay: this._setApmConfig(config.applePay, DefaultConfig.applePay),
       buttonId: this._getValueOrDefault(config.buttonId, DefaultConfig.buttonId),
       bypassCards: this._getValueOrDefault(config.bypassCards, DefaultConfig.bypassCards),
-      cachetoken: this._getValueOrDefault(config.cachetoken, DefaultConfig.cachetoken),
       cancelCallback: this._getValueOrDefault(config.cancelCallback, DefaultConfig.cancelCallback),
       componentIds: this._setComponentIds(config.componentIds),
       components: this._setComponentsProperties(config.components),
@@ -43,7 +42,6 @@ export class ConfigResolver {
       origin: this._getValueOrDefault(config.origin, DefaultConfig.origin),
       panIcon: this._getValueOrDefault(config.panIcon, DefaultConfig.panIcon),
       placeholders: this._setPlaceholders(config.placeholders),
-      requestTypes: this._getValueOrDefault(config.requestTypes, DefaultComponentsRequestTypes),
       styles: this._getValueOrDefault(config.styles, DefaultConfig.styles),
       submitCallback: this._getValueOrDefault(config.submitCallback, DefaultConfig.submitCallback),
       submitFields: this._getValueOrDefault(config.submitFields, DefaultSubmitFields),
@@ -51,7 +49,6 @@ export class ConfigResolver {
       submitOnError: this._getValueOrDefault(config.submitOnError, DefaultConfig.submitOnError),
       submitOnSuccess: this._getValueOrDefault(config.submitOnSuccess, DefaultConfig.submitOnSuccess),
       successCallback: this._getValueOrDefault(config.successCallback, DefaultConfig.successCallback),
-      threedinit: this._getValueOrDefault(config.threedinit, DefaultConfig.threedinit),
       translations: this._getValueOrDefault(config.translations, DefaultConfig.translations),
       visaCheckout: this._setApmConfig(config.visaCheckout, DefaultConfig.visaCheckout)
     };

--- a/src/client/config/schema/ConfigSchema.ts
+++ b/src/client/config/schema/ConfigSchema.ts
@@ -51,7 +51,6 @@ export const ConfigSchema: Joi.ObjectSchema = Joi.object().keys({
   bypassCards: Joi.array().items(
     Joi.string().valid('AMEX', 'ASTROPAYCARD', 'DINERS', 'DISCOVER', 'JCB', 'MASTERCARD', 'MAESTRO', 'PIBA', 'VISA')
   ),
-  cachetoken: Joi.string().allow(''),
   cancelCallback: Joi.any(),
   componentIds: Joi.object()
     .keys({
@@ -89,9 +88,6 @@ export const ConfigSchema: Joi.ObjectSchema = Joi.object().keys({
   jwt: Joi.string().required(),
   livestatus: Joi.number().valid(0, 1),
   origin: Joi.string().allow(''),
-  requestTypes: Joi.array().items(
-    Joi.string().valid('ACCOUNTCHECK', 'AUTH', 'JSINIT', 'RISKDEC', 'SUBSCRIPTION', 'THREEDQUERY')
-  ),
   panIcon: Joi.boolean(),
   placeholders: Joi.object().keys({
     pan: Joi.string().allow(''),
@@ -105,7 +101,6 @@ export const ConfigSchema: Joi.ObjectSchema = Joi.object().keys({
   submitOnCancel: Joi.boolean(),
   submitOnError: Joi.boolean(),
   submitOnSuccess: Joi.boolean(),
-  threedinit: Joi.string().allow(''),
   translations: Joi.object(),
   visaCheckout: {
     buttonSettings: Joi.object().keys({

--- a/src/shared/model/config/IConfig.ts
+++ b/src/shared/model/config/IConfig.ts
@@ -13,7 +13,6 @@ export interface IConfig {
   applePay?: IApplePay | {};
   buttonId?: string;
   bypassCards?: BypassCards[];
-  cachetoken?: string;
   cancelCallback?: any;
   components?: IComponentsConfig;
   componentIds?: IComponentsIds;
@@ -30,7 +29,6 @@ export interface IConfig {
   origin?: string;
   panIcon?: boolean;
   placeholders?: IPlaceholdersConfig;
-  requestTypes?: string[];
   styles?: IStyles;
   submitCallback?: any;
   submitFields?: string[];
@@ -38,7 +36,6 @@ export interface IConfig {
   submitOnError?: boolean;
   submitOnSuccess?: boolean;
   successCallback?: any;
-  threedinit?: string;
   translations?: {};
   visaCheckout?: IVisaCheckout | {};
 }


### PR DESCRIPTION
Let me explained what's happened here:

- `requestTypes` from main config has been removed - it's not used anywhere it's just available in API; even if merchant specifies it it's doing nothing

- `cachetoken` and `threedinit` in main config - removed - that's the same situation like in `requestTypes`;  it's available in API but was never assigned to any property / field in code, IMO useless

From my point of view we can delete those properties from config and don't need to have backward compatibility. 

Let me know guys if that make sense.