### PR TITLE
created new observable from stMessages so it wont spam with console errors

### DIFF
--- a/src/application/core/shared/MessageBus.ts
+++ b/src/application/core/shared/MessageBus.ts
@@ -93,7 +93,9 @@ export class MessageBus implements Subscribable<IMessageBusEvent> {
         const frames: FrameCollection = this.frameAccessor.getFrameCollection();
         const controlFrame: ControlFrameWindow = frames[frameName] as ControlFrameWindow;
 
-        return controlFrame.stMessages;
+        return new Observable(subscriber => {
+          controlFrame.stMessages.subscribe(value => subscriber.next(value));
+        });
       })
     );
   }

--- a/src/application/core/shared/MessageBus.ts
+++ b/src/application/core/shared/MessageBus.ts
@@ -93,7 +93,7 @@ export class MessageBus implements Subscribable<IMessageBusEvent> {
         const frames: FrameCollection = this.frameAccessor.getFrameCollection();
         const controlFrame: ControlFrameWindow = frames[frameName] as ControlFrameWindow;
 
-        return new Observable(subscriber => {
+        return new Observable<IMessageBusEvent>(subscriber => {
           controlFrame.stMessages.subscribe(value => subscriber.next(value));
         });
       })


### PR DESCRIPTION
I noticed that there was a lots of error being thrown in the console in react app so I took some time to find the source and fix it. I haven't noticed that those errors somehow affected the form functionality but it would better to get rid of them anyway.