### PR TITLE
STJS-636 added cybertonica timeout

### DIFF
--- a/src/application/core/integrations/Cybertonica.ts
+++ b/src/application/core/integrations/Cybertonica.ts
@@ -42,7 +42,6 @@ export class Cybertonica implements ICybertonica {
 
     this.tid = Promise.race([tid, timeout]);
     this.tid.then(value => this.storage.setItem(Cybertonica.TID_KEY, value));
-    this.tid.then(value => console.log('TID', value));
 
     return this.tid;
   }


### PR DESCRIPTION
The payment was freezing when the cybertonica script could not be loaded (eg. blocked by the ad-block). I added a simple timeout so that when the TID is not resolved within 5 seconds it just skips the cybertonica completely and sends the payment without TID.